### PR TITLE
gha: freeze semgrep version

### DIFF
--- a/.github/workflows/test-rules.yaml
+++ b/.github/workflows/test-rules.yaml
@@ -7,12 +7,12 @@ jobs:
   main:
     runs-on: ubuntu-22.04
 
+    # Note: the non-root flavor doesn't work on GHA (e.g., 1.56.0-nonroot).
+    container: returntocorp/semgrep@sha256:259562bd67f81edb4600090a960910b2a21e1e0e95cc13ad0d8dc172193039cf # 1.56.0
+
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-
-      - name: Install Dependencies
-        run: python3 -m pip install semgrep
 
       # Checks for syntax errors and runs 'p/semgrep-rule-lints'.
       - name: Validate Rules


### PR DESCRIPTION
This freezes the semgrep version to avoid sudden breaking changes in the CIs.

For example, 1.57.0 (https://github.com/semgrep/semgrep/releases/tag/v1.57.0) added a change that breaks the CIs:

> Rules stored under an "hidden" directory (e.g., dir/.hidden/myrule.yml)
> are now processed when using --config .
> We used to skip dot files under dir, but keeping rules/.semgrep.yml,
> but not path/.github/foo.yml, but keeping src/.semgrep/bad_pattern.yml
> but not ./.pre-commit-config.yaml, ... This was mainly because
> we used to fetch rules from ~/.semgrep/ implicitely when --config
> was not given, but this feature was removed, so now we can keep it simple. (hidden_rules)