### PR TITLE
debt: upgrade semgrep from v1.56.0 to v1.63.0

### DIFF
--- a/.github/workflows/test-rules.yaml
+++ b/.github/workflows/test-rules.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     # Note: the non-root flavor doesn't work on GHA (e.g., 1.56.0-nonroot).
-    container: returntocorp/semgrep@sha256:259562bd67f81edb4600090a960910b2a21e1e0e95cc13ad0d8dc172193039cf # 1.56.0
+    container: returntocorp/semgrep@sha256:396f4ad7a655289e764ab2f92733e6195c166ff2f042e0d40505a5850432b9ac # 1.63.0
 
     steps:
       - name: Checkout
@@ -16,7 +16,18 @@ jobs:
 
       # Checks for syntax errors and runs 'p/semgrep-rule-lints'.
       - name: Validate Rules
-        run: semgrep scan --validate --config ./
+        shell: bash
+        run: |
+          config_args=()
+
+          # As of semgrep 1.58.0, hidden directories are no longer excluded
+          # when passing "--validate ./" thus we need to manually exclude hidden
+          # directories.
+          while IFS= read -r -d '' dir; do
+            config_args+=( "--config=$dir" )
+          done < <(find . -maxdepth 1 -mindepth 1 -type d -not -path '*/\.*' -print0)
+          
+          semgrep scan --validate "${config_args[@]}"
 
       - name: Test Rules
         run: semgrep --test ./


### PR DESCRIPTION
This upgrades semgrep to latest version (v1.63.0), and adds the logic needed to exclude hidden directories from our checks (follow-up of https://github.com/saleor/semgrep-rules/pull/2).