### PR TITLE
Relax timing attack comparison rule

### DIFF
--- a/typescript/lang/security/audit/timing-attack-comparison.yaml
+++ b/typescript/lang/security/audit/timing-attack-comparison.yaml
@@ -33,4 +33,4 @@ rules:
       - focus-metavariable: $SECRET
       - metavariable-regex:
           metavariable: $SECRET
-          regex: (?i).+(pass|secret|api|apiKey|auth|hash|sig|token).+
+          regex: (?i).+(password|secret|apiKey|auth|hash|sig|token).+


### PR DESCRIPTION
The `typescript.lang.security.audit.timing-attack-comparison` rule was too sensitive:
- `pass` may match too many words such as "to pass something"
- `api` may match too many unrelated things such as `APIUrl`