### PR TITLE
fix: error when using default action config

### DIFF
--- a/.github/workflows/action-run-semgrep.yaml
+++ b/.github/workflows/action-run-semgrep.yaml
@@ -36,7 +36,7 @@ on:
           - p/python (public library)
           - ./rules/my-rule.yaml (single YAML file)
           - ./my-rules/ (directory of N YAML files)
-          
+
           By default the rules will be added on top of this workflow's default rules
           (see the input `use_default_config` and the environment variable
           `DEFAULT_CONFIG` for more information).
@@ -68,7 +68,8 @@ env:
     auto
     p/ci
     r/yaml.github-actions
-    ./saleor-rules
+    ./saleor-rules/yaml
+    ./saleor-rules/typescript
   # yaml.github-actions.[...].run-shell-injection is duplicate of saleor-rules.yaml.github-actions.script-injection
   DEFAULT_EXCLUDE_RULE_IDS: |
     yaml.github-actions.security.run-shell-injection.run-shell-injection
@@ -119,7 +120,7 @@ jobs:
           EXCLUDE_RULES: ${{ inputs.exclude_rules }}
         run: |
           set -u -o pipefail
-          
+
           cmd_args=(
               # Do not check for version update as we are inside a CI.
               "--disable-version-check"
@@ -131,32 +132,32 @@ jobs:
               # the users to be explicit.
               "--no-git-ignore"
           )
-          
+
           # Add extra logging if the runner was run with debug logging.
           test -z "${RUNNER_DEBUG+x}" || cmd_args+=( "--verbose" )
-          
+
           if [ "$USE_DEFAULT_CONFIG" == true ]; then
             CONFIG_PATHS="$DEFAULT_CONFIG $CONFIG_PATHS"
           fi
-          
+
           if [ "$USE_DEFAULT_EXCLUDE_RULES" == true ]; then
             EXCLUDE_RULES="$DEFAULT_EXCLUDE_RULE_IDS $EXCLUDE_RULES"
           fi
-          
+
           # Gather the config input whitespace-separate value
           # into a list of `--config=<value>` arguments.
           read -d '' -r -a configs < <(echo "$CONFIG_PATHS") || true
           for cfg in "${configs[@]}"; do
             cmd_args+=( "--config=$cfg" )
           done
-          
+
           # Gather the excluded rules ID into a list
           # of `--exclude-rule=<value>` arguments.
           read -d '' -r -a exclude_rules < <(echo "$EXCLUDE_RULES") || true
           for excluded_rule_id in "${exclude_rules[@]}"; do
             cmd_args+=( "--exclude-rule=$excluded_rule_id" )
           done
-          
+
           semgrep ci "${cmd_args[@]}"
 
       - uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # 4.3.0


### PR DESCRIPTION
This fixes a crash when using the default config from our repository, the workflow would error-out with the following:

```
$ docker-here \
    returntocorp/semgrep@sha256:396f4ad7a655289e764ab2f92733e6195c166ff2f042e0d40505a5850432b9ac \
    semgrep \
      --metrics=off \
      --config=./ ./

semgrep error: Invalid rule schema
  --> .github/dependabot.yaml:1
1  | version: 2
2  |
3  | updates:
4  |   - package-ecosystem: "github-actions"
5  |     directory: "/"
6  |     schedule:
7  |       interval: "monthly"
8  |     cooldown:
9  |       default-days: 21 # 3 weeks

One of these properties is missing: 'rules'

[ERROR] invalid configuration file found (1 configs were invalid)
```

This is due to Semgrep selecting all YAML files, including the ones under `.github/`. In the past, Semgrep was excluding hidden folders which isn't the case anymore.

Results after the changes:

```
$ docker-here \
    returntocorp/semgrep@sha256:396f4ad7a655289e764ab2f92733e6195c166ff2f042e0d40505a5850432b9ac \
    semgrep \
      --metrics=off \
      --config=./yaml \
      --config=./typescript ./

┌─────────────┐
│ Scan Status │
└─────────────┘
  Scanning 13 files (only git-tracked) with 2 Code rules:

  CODE RULES
  Scanning 6 files.

  SUPPLY CHAIN RULES

  No rules to run.

  PROGRESS

  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00

┌──────────────┐
│ Scan Summary │
└──────────────┘
Some files were skipped or only partially analyzed.
  Scan was limited to files tracked by git.
  Scan skipped: 2 files matching .semgrepignore patterns
  For a full list of skipped files, run semgrep with the --verbose flag.

Ran 1 rule on 6 files: 0 findings.
```