### PR TITLE
feat: add rule ensuring OIDC systems are protected

### DIFF
--- a/.github/workflows/action-run-semgrep.yaml
+++ b/.github/workflows/action-run-semgrep.yaml
@@ -1,23 +1,12 @@
 name: Semgrep CI
 on:
   workflow_call:
-    secrets:
-      SARIF_TO_GH_COMMENT_APP_ID:
-        required: true
-        description: >
-          The ID of the GitHub application that exports SARIF results as pull request
-          annotations.
-      SARIF_TO_GH_COMMENT_APP_INSTALL_ID:
-        required: true
-        description: >
-          The repository or organization's installation ID of the GitHub application
-          exporting SARIF results as pull request annotations.
-      SARIF_TO_GH_COMMENT_APP_KEY:
-        required: true
-        description: >
-          The private key of the GitHub application exporting SARIF results
-          as pull request annotations.
     inputs:
+      sarif-export-environment:
+        type: string
+        required: true
+        description: The GitHub environment to use to exports results.
+
       check_name:
         type: string
         default: ""
@@ -74,14 +63,17 @@ env:
   DEFAULT_EXCLUDE_RULE_IDS: |
     yaml.github-actions.security.run-shell-injection.run-shell-injection
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   scan:
     if: (github.actor != 'dependabot[bot]')
     name: semgrep/ci
     runs-on: ubuntu-24.04
+
+    permissions:
+      contents: read
+
     container:
       # Note: the non-root flavor doesn't work on GHA (e.g., 1.57.0-nonroot).
       image: returntocorp/semgrep:1.153.1@sha256:50b839b576d76426efd3e5cffda2db0d8c403f53aa76e91d42ccf51485ac336c
@@ -91,6 +83,9 @@ jobs:
       - if: ${{ !env.ACT }}
         name: Checkout Caller's Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Semgrep expects the head instead of the merge commit
+          ref: ${{ github.event.pull_request.head.sha }}
 
       # Clone the custom semgrep rules (this GitHub repository).
       - if: ${{ !env.ACT }}
@@ -131,6 +126,9 @@ jobs:
               # 'git add --force' from being silently ignored, thus forcing
               # the users to be explicit.
               "--no-git-ignore"
+              # Prevents Semgrep from scanning the repo 'saleor/semgrep-rules' as it
+              # can cause unrelated findings
+              "--exclude=./saleor-rules/"
           )
 
           # Add extra logging if the runner was run with debug logging.
@@ -158,6 +156,7 @@ jobs:
             cmd_args+=( "--exclude-rule=$excluded_rule_id" )
           done
 
+          echo "Running semgrep with: ${cmd_args[*]}"
           semgrep ci "${cmd_args[@]}"
 
       - uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # 4.3.0
@@ -178,6 +177,7 @@ jobs:
       - scan
     name: SARIF to PR Annotations
     runs-on: ubuntu-24.04
+    environment: ${{ inputs.sarif-export-environment }}
     container:
       # Note: distroless flavor doesn't work on GHA.
       image: ghcr.io/nyankiyoshi/less-advanced-security@sha256:689f73bed448ce40ca4ed01f6585f22665c0c302ed0e882d1fc78016c12f2880 # 0.5.0

--- a/.github/workflows/run-semgrep.yaml
+++ b/.github/workflows/run-semgrep.yaml
@@ -4,12 +4,16 @@ on:
     types:
       - synchronize
       - opened
-permissions:
-  contents: read
 jobs:
   scanner:
+    permissions:
+      contents: read
     uses: ./.github/workflows/action-run-semgrep.yaml
-    secrets:
-      SARIF_TO_GH_COMMENT_APP_ID: ${{ secrets.SARIF_TO_GH_COMMENT_APP_ID }}
-      SARIF_TO_GH_COMMENT_APP_INSTALL_ID: ${{ secrets.SARIF_TO_GH_COMMENT_APP_INSTALL_ID }}
-      SARIF_TO_GH_COMMENT_APP_KEY: ${{ secrets.SARIF_TO_GH_COMMENT_APP_KEY }}
+    with:
+      sarif-export-environment: semgrep-export-sarif
+    # Required to work with environment currently
+    # Refs:
+    # - https://github.com/github/roadmap/issues/636
+    # - https://github.com/actions/runner/issues/1490
+    # - https://github.com/actions/runner/issues/3206
+    secrets: inherit

--- a/README.md
+++ b/README.md
@@ -38,10 +38,12 @@ semgrep -c /path-to-the-clone-semgrep-rules .
 
 ### YAML
 
-| ID                                                                                                                                    | Impact | Confidence | Description                                                                                                                         |
-| ------------------------------------------------------------------------------------------------------------------------------------- | ------ | ---------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| [yaml.github-actions.security.audit.shell-script-injection](yaml/github-actions/security/audit/shell-script-injection.yaml)           | HIGH   | HIGH       | Ensures no string interpolations (`${{ ... }}`) are present inside `run` blocks of GitHub Actions.                                  |
-| [yaml.github-actions.security.audit.secrets-without-environment](yaml/github-actions/security/audit/secrets-without-environment.yaml) | HIGH   | HIGH       | Matches GitHub Workflows that use secrets (other than GITHUB_TOKEN) without providing a GitHub Environment (`environment` keyword). |
+| ID                                                                                                                                                | Impact | Confidence | Description                                                                                                                         |
+| ------------------------------------------------------------------------------------------------------------------------------------------------- | ------ | ---------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| [yaml.github-actions.security.audit.shell-script-injection](yaml/github-actions/security/audit/shell-script-injection.yaml)                       | HIGH   | HIGH       | Ensures no string interpolations (`${{ ... }}`) are present inside `run` blocks of GitHub Actions.                                  |
+| [yaml.github-actions.security.audit.secrets-without-environment](yaml/github-actions/security/audit/secrets-without-environment.yaml)             | HIGH   | HIGH       | Matches GitHub Workflows that use secrets (other than GITHUB_TOKEN) without providing a GitHub Environment (`environment` keyword). |
+| [yaml.github-actions.security.audit.global-permissions-used](yaml/github-actions/security/audit/global-permissions-used.yaml)                     | HIGH   | HIGH       | Prevents workflows from settings global permissions.                                                                                |
+| [yaml.github-actions.security.audit.oidc-id-token-without-environment](yaml/github-actions/security/audit/oidc-id-token-without-environment.yaml) | HIGH   | HIGH       | Ensures a `environment` key is provided whenever using OIDC to external systems are verifying the workflow run is authorized.       |
 
 ## Contributing
 

--- a/yaml/github-actions/security/audit/global-permissions-used.test.yaml
+++ b/yaml/github-actions/security/audit/global-permissions-used.test.yaml
@@ -1,0 +1,71 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+
+# Should match when using global permissions
+permissions:
+  # ruleid: global-permissions-used
+  contents: read
+  id-token: write # Required for OIDC
+  releases: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hello
+---
+name: CI
+
+on:
+  push:
+    branches: [main]
+
+# Should also match when using a string instead of an object
+# ruleid: global-permissions-used
+permissions: read-all
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hello
+---
+name: CI
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    # ok: global-permissions-used
+    permissions:
+      contents: read
+      id-token: write # Required for OIDC
+      releases: read
+    steps:
+      - run: echo hello
+---
+name: CI
+
+on:
+  push:
+    branches: [main]
+
+# ok: global-permissions-used
+permissions: {}
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    # ok: global-permissions-used
+    permissions:
+      contents: read
+      id-token: write # Required for OIDC
+      releases: read
+    steps:
+      - run: echo hello

--- a/yaml/github-actions/security/audit/global-permissions-used.yaml
+++ b/yaml/github-actions/security/audit/global-permissions-used.yaml
@@ -1,9 +1,6 @@
 rules:
   - id: global-permissions-used
     message: |
-      Permissions should be set at the job-level rather than globally.
-      Move `permissions` block inside the `job` property instead.
-
       Global permissions apply to every job in the workflow, which can grant unnecessary
       privileges to jobs that do not require them.
 

--- a/yaml/github-actions/security/audit/global-permissions-used.yaml
+++ b/yaml/github-actions/security/audit/global-permissions-used.yaml
@@ -1,0 +1,37 @@
+rules:
+  - id: global-permissions-used
+    message: |
+      Permissions should be set at the job-level rather than globally.
+      Move `permissions` block inside the `job` property instead.
+
+      Global permissions apply to every job in the workflow, which can grant unnecessary
+      privileges to jobs that do not require them.
+
+      Instead, define `permissions` at the job level so each job only receives the
+      minimum privileges it requires. This follows the principle of least privilege
+      and reduces the blast radius if a job is compromised.
+
+      Note: Setting `permissions: {}` globally to disable all permissions is acceptable.
+    severity: ERROR
+    languages: [yaml]
+    metadata:
+      category: security
+      technology: github-actions
+      cwe: "CWE-250: Execution with Unnecessary Privileges"
+      likelihood: MEDIUM
+      confidence: HIGH
+      impact: HIGH
+
+    patterns:
+      - pattern-inside: |
+          permissions: $X
+          ...
+          jobs:
+            ...
+      # Allow denying all permissions globally
+      - pattern-not: |
+          permissions: {}
+          ...
+          jobs:
+            ...
+      - focus-metavariable: $X

--- a/yaml/github-actions/security/audit/oidc-id-token-without-environment.test.yaml
+++ b/yaml/github-actions/security/audit/oidc-id-token-without-environment.test.yaml
@@ -1,0 +1,162 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+
+# Should match when using global permissions
+# ok: oidc-id-token-without-environment
+permissions:
+  contents: read
+  id-token: write # Required for OIDC
+  releases: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: foo
+    steps:
+      - run: echo hello
+---
+name: CI
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    # Should match when using job-level permissions
+    # ruleid: oidc-id-token-without-environment
+    permissions:
+      contents: read
+      id-token: write # Required for OIDC
+      releases: read
+
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hello
+---
+name: CI
+
+on:
+  push:
+    branches: [main]
+
+# Test surrounded by other jobs
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    steps:
+      - if: ${{ true }}
+        name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+  deploy:
+    runs-on: ubuntu-latest
+    # ruleid: oidc-id-token-without-environment
+    permissions:
+      id-token: write
+    steps:
+      - name: do something
+        run: |
+          echo "$foo"
+  finalize:
+    runs-on: ubuntu-latest
+    steps:
+      - if: ${{ true }}
+        name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+---
+name: CI
+
+on:
+  push:
+    branches: [main]
+
+# Testing default permissions set globally
+# ok: oidc-id-token-without-environment
+permissions: {}
+
+jobs:
+  deploy:
+    # ruleid: oidc-id-token-without-environment
+    permissions:
+      id-token: write
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hello
+---
+name: CI
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  # Re-usable workflows shouldn't match as we can't put a 'environment' key
+  # However, the actual reusable workflow MUST still define one (and this
+  # semgrep rule will catch the issue in the reusable workflow if it's from
+  # Saleor)
+  reusable-workflow:
+    # ok: oidc-id-token-without-environment
+    permissions:
+      id-token: write
+    uses: saleor/foo
+---
+name: CI
+
+on:
+  push:
+    branches: [main]
+
+# Should still not match when permissions are global and it's using
+# a reusable workflow
+# ok: oidc-id-token-without-environment
+permissions:
+  id-token: write
+
+jobs:
+  reusable-workflow:
+    uses: saleor/foo
+---
+name: CI
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    # Should still match even if an **unrelated** job uses an
+    # environment.
+    environment: ok
+    steps:
+      - run: xxx
+  deploy:
+    # ruleid: oidc-id-token-without-environment
+    permissions:
+      contents: read
+      id-token: write # Required for OIDC
+      releases: read
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hello
+---
+name: CI
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    # Shouldn't match when using an environment
+    # ok: oidc-id-token-without-environment
+    permissions:
+      contents: read
+      id-token: write # Required for OIDC
+      releases: read
+    environment: ok
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hello

--- a/yaml/github-actions/security/audit/oidc-id-token-without-environment.yaml
+++ b/yaml/github-actions/security/audit/oidc-id-token-without-environment.yaml
@@ -1,0 +1,61 @@
+rules:
+  - id: oidc-id-token-without-environment
+    message: |
+      This GitHub Workflow allows the job to request an OIDC ID token
+      (`id-token: write`) but does not define a GitHub Environment.
+
+      Without an environment, the issued OIDC token is not scoped to any
+      specific deployment workflow and thus can be requested by any workflow.
+      This token is trusted by external systems (e.g., cloud providers or
+      package registries), this increases the risk that a compromised workflow,
+      pull request workflow could perform unintended actions such as publishing
+      packages or accessing cloud resources.
+
+      GitHub Environments allow to enforce protection rules such as branch protection,
+      required reviewers and environment-specific secrets. When OIDC tokens are tied
+      to an environment, external identity providers can validate the environment in the
+      OIDC claims to ensure that only approved deployment jobs can obtain credentials.
+
+      To remediate this issue:
+      1. Add the `environment` key to the job requesting the OIDC token.
+      2. [IMPORTANT :warning:] Configure the external identity provider to only
+         trust tokens issued for that given environment.
+
+      References:
+      - https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments
+      - PyPI: https://docs.pypi.org/trusted-publishers/adding-a-publisher/#github-actions
+      - NPM: https://docs.npmjs.com/trusted-publishers#step-1-add-a-trusted-publisher-on-npmjscom
+    severity: ERROR
+    languages: [yaml]
+    metadata:
+      category: security
+      technology: github-actions
+      cwe: "CWE-862: Missing Authorization"
+      likelihood: MEDIUM
+      confidence: HIGH
+      impact: HIGH
+
+    patterns:
+      - pattern-inside: |
+          jobs:
+            ...
+      - pattern-inside: |
+          $JOB:
+            ...
+      - pattern: |
+          permissions:
+            ...
+            id-token: write
+            ...
+
+      # Exclude jobs that properly define an environment
+      - pattern-not-inside: |
+          ...
+          environment: ...
+          ...
+
+      # Exclude reusable workflows
+      - pattern-not-inside: |
+          ...
+          uses: ...
+          ...


### PR DESCRIPTION
Adds 2 rules:
1. Ensures global permissions are not set - this simplifies the OIDC Semgrep rule (and future rules) and prevents overly privileged workflows
2. Tries to create a guardrail that ensures people authoring workflows are properly configuring the external systems (AWS, NPM, PyPI) to verify the `environment` OIDC claim which lowers the risk of unauthorized access.