### PR TITLE
feat: add rule blocking dangerous workflow events

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,11 @@ semgrep -c /path-to-the-clone-semgrep-rules .
 
 ### YAML
 
-| ID                                                                                                                                    | Impact | Confidence | Description                                                                                                                         |
-| ------------------------------------------------------------------------------------------------------------------------------------- | ------ | ---------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| [yaml.github-actions.security.audit.shell-script-injection](yaml/github-actions/security/audit/shell-script-injection.yaml)           | HIGH   | HIGH       | Ensures no string interpolations (`${{ ... }}`) are present inside `run` blocks of GitHub Actions.                                  |
-| [yaml.github-actions.security.audit.secrets-without-environment](yaml/github-actions/security/audit/secrets-without-environment.yaml) | HIGH   | HIGH       | Matches GitHub Workflows that use secrets (other than GITHUB_TOKEN) without providing a GitHub Environment (`environment` keyword). |
+| ID                                                                                                                                    | Impact | Confidence | Description                                                                                                                                                                 |
+| ------------------------------------------------------------------------------------------------------------------------------------- | ------ | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [yaml.github-actions.security.audit.shell-script-injection](yaml/github-actions/security/audit/shell-script-injection.yaml)           | HIGH   | HIGH       | Ensures no string interpolations (`${{ ... }}`) are present inside `run` blocks of GitHub Actions.                                                                          |
+| [yaml.github-actions.security.audit.secrets-without-environment](yaml/github-actions/security/audit/secrets-without-environment.yaml) | HIGH   | HIGH       | Matches GitHub Workflows that use secrets (other than GITHUB_TOKEN) without providing a GitHub Environment (`environment` keyword).                                         |
+| [yaml.github-actions.security.audit.dangerous-event-type](yaml/github-actions/security/audit/dangerous-event-type.yaml)               | HIGH   | LOW        | Blocks workflows that use dangerous events such as `pull_request_target` or `issue_comment` which can lead to unauthorized read-write access, as well as access to secrets. |
 
 ## Contributing
 

--- a/yaml/github-actions/security/audit/dangerous-event-type.test.yaml
+++ b/yaml/github-actions/security/audit/dangerous-event-type.test.yaml
@@ -1,0 +1,36 @@
+on:
+  # ruleid: dangerous-event-type
+  pull_request_target:
+---
+on:
+  push:
+  # Should match even when surrounded
+  # ruleid: dangerous-event-type
+  pull_request_target:
+  pull_request:
+---
+# Should match when using `{}` object syntax
+# ruleid: dangerous-event-type
+on: { "push": null, "pull_request_target": null, "pull_request": null }
+---
+on:
+  # Should still match even if it's a multi-line list
+  # ruleid: dangerous-event-type
+  - pull_request_target
+---
+on:
+  - pull_request
+  # Should match even when it's surrounded
+  # ruleid: dangerous-event-type
+  - pull_request_target
+  - push
+---
+# ruleid: dangerous-event-type
+on: [pull_request_target]
+---
+# Should match even when it's surrounded
+# ruleid: dangerous-event-type
+on: [push, pull_request_target, pull_request]
+---
+# ok: dangerous-event-type
+on: [push, pull_request]

--- a/yaml/github-actions/security/audit/dangerous-event-type.yaml
+++ b/yaml/github-actions/security/audit/dangerous-event-type.yaml
@@ -1,0 +1,66 @@
+rules:
+  - id: dangerous-event-type
+    message: >-
+      This workflow is triggered by the $X event, which **can be initiated by
+      external or untrusted actors**. This can allow unauthorized parties
+      with repository privileges and can lead to being able to access secrets
+      or perform write operations.
+
+      An attacker may be able to craft repository activity (for example comments,
+      pull requests, or discussions) that causes the workflow to execute malicious
+      code (such as exfiltrating secrets, the GITHUB_TOKEN, or even move laterally)
+
+      To reduce risk:
+      - Avoid triggering privileged workflows from externally controllable events,
+        such as $X
+      - Restrict permissions using the `permissions` field.
+      - Avoid using secrets in workflows triggered by untrusted input
+      - Use safer events such as `push` or `pull_request`
+      - Avoid using GitHub caches in sensitive or privileged workflows
+
+      Reference:
+      https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions
+    severity: ERROR
+    languages:
+      - yaml
+    metadata:
+      cwe:
+        - "CWE-913: Improper Control of Dynamically-Managed Code Resources"
+      category: security
+      subcategory:
+        - audit
+      technology:
+        - github-actions
+      likelihood: MEDIUM
+      # Low confidence due to matching private repositories and in general exploitability
+      # really depends on the context for this rule.
+      confidence: LOW
+      impact: HIGH
+    patterns:
+      - pattern-either:
+          - pattern-inside: |
+              on: [..., $X, ...]
+          - pattern-inside: |
+              on:
+                ...
+                $X: ...
+                ...
+          - pattern-inside: |
+              on: $X
+      - focus-metavariable: $X
+      - metavariable-regex:
+          metavariable: $X
+          # List: https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows
+          regex: "(?i).*(\
+            pull_request_target|\
+            check_run|\
+            check_suite|\
+            discussion|\
+            discussion_comment|\
+            fork|\
+            issue_comment|\
+            issues|\
+            pull_request_comment|\
+            pull_request_review|\
+            pull_request_review_comment|\
+            watch).*"


### PR DESCRIPTION
Adds a rule that atttempts to match all events that could be initiated by an external party which can lead to unauthorized access (especially the most prevalent issues such as `pull_request_target` and `issue_comment`)